### PR TITLE
fix: ykfの証明書エラーを回避するためhttpに変更した

### DIFF
--- a/src/detail/ykf/detail_ykf.js
+++ b/src/detail/ykf/detail_ykf.js
@@ -1,6 +1,6 @@
 // YKF 詳細
 const createBrowser = require("../../browser-factory");
-const URL = "https://www.yaeyama.co.jp/operation.html";
+const URL = "http://www.yaeyama.co.jp/operation.html";
 const consts = require("../../consts.js");
 const config = require("../../config/config");
 const firebase = require("../../repository/firebase_repository");

--- a/src/list/ykf/ykf_list.js
+++ b/src/list/ykf/ykf_list.js
@@ -1,5 +1,5 @@
 const createBrowser = require("../../browser-factory");
-const URL = "https://www.yaeyama.co.jp/operation.html";
+const URL = "http://www.yaeyama.co.jp/operation.html";
 const consts = require("../../consts.js");
 const config = require("../../config/config");
 const firebase = require("../../repository/firebase_repository");

--- a/src/list/ykf/ykf_time_and_announce.js
+++ b/src/list/ykf/ykf_time_and_announce.js
@@ -1,5 +1,5 @@
 const createBrowser = require("../../browser-factory");
-const URL = "https://www.yaeyama.co.jp/operation.html";
+const URL = "http://www.yaeyama.co.jp/operation.html";
 const consts = require("../../consts.js");
 const config = require("../../config/config");
 const firebase = require("../../repository/firebase_repository");


### PR DESCRIPTION
## 概要
- https://github.com/ikemura23/yaimafuni-batch/issues/75

## 背景
- Cloud Watchでエラーログがでてた


```
  Error: net::ERR_CERT_DATE_INVALID at https://www.yaeyama.co.jp/operation.html
      at navigate (/Users/k_ikemura/dev/yaimafuni-batch/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Frame.js:184:27)
      at async Deferred.race (/Users/k_ikemura/dev/yaimafuni-batch/node_modules/puppeteer-core/lib/cjs/puppeteer/util/Deferred.js:36:20)
      at async CdpFrame.goto (/Users/k_ikemura/dev/yaimafuni-batch/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Frame.js:150:25)
      at async CdpPage.goto (/Users/k_ikemura/dev/yaimafuni-batch/node_modules/puppeteer-core/lib/cjs/puppeteer/api/Page.js:574:20)
      at async module.exports (/Users/k_ikemura/dev/yaimafuni-batch/src/list/ykf/ykf_list.js:16:5)
      at async exports.handler (/Users/k_ikemura/dev/yaimafuni-batch/index.js:37:5)
```

ykfサイトのサイト証明書が切れてるようだ。。。
<img width="813" alt="image" src="https://github.com/user-attachments/assets/e3912db4-b594-4068-b47c-d3b426565be9" />


## 対応内容
- `ignoreHTTPSErrors: true`を追加してもダメ
```js
const browser = await puppeteer.launch({
  args: ['--ignore-certificate-errors'],
  headless: true,
  ignoreHTTPSErrors: true, // 証明書エラーを無視
});
```

httpでは取得できるので、いったんhttpにする
証明書がなおったらhttpsに戻す

## 備考
-
